### PR TITLE
remove lots of empty lines in output

### DIFF
--- a/src/main/java/com/schibsted/security/artishock/cli/view/Renderer.java
+++ b/src/main/java/com/schibsted/security/artishock/cli/view/Renderer.java
@@ -54,7 +54,7 @@ public class Renderer {
       case JSON:
         return serializeToJSON(object) + "\n";
       case TEXT:
-        return Joiner.on("\n").join(object.stream().map(Object::toString).collect(Collectors.toList())) + "\n";
+        return Joiner.on("\n").join(object.stream().map(Object::toString).filter(s -> !s.isEmpty()).collect(Collectors.toList())) + "\n";
       default:
         throw new RuntimeException("Unexpected output format");
     }


### PR DESCRIPTION
output of the command `artishock not-claimed --package-system pypi --local pypi-local --query-upstream` contains a lot of empty lines without this