### PR TITLE
Throw exception on failing download

### DIFF
--- a/src/main/java/com/schibsted/security/artishock/shared/HttpClient.java
+++ b/src/main/java/com/schibsted/security/artishock/shared/HttpClient.java
@@ -70,6 +70,9 @@ public class HttpClient {
     var request = HttpClient.prepareRequest(connectionInfo, path);
 
     try (var response = HttpClient.execute(request)) {
+      if (!response.isSuccessful()) {
+        throw new RuntimeException("Download not successful from " + request.url());
+      }
       return response.body().string();
     } catch (IOException e) {
       throw new RuntimeException("Failed to get body from " + request.url());


### PR DESCRIPTION
if the download fails, report that as an exception instead of trying to parse the error message body