### PR TITLE
Update linked text to 'OpenJDK 17'

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ artishock repo-stats --package-system maven --repo small-remote-cache
 Use `--verbose` for verbose output and `--stacktrace` to get the full stack trace rather than just the message.
 
 ## Developer notes
-*Prerequisite: [OpenJDK7](https://adoptium.net/)*
+*Prerequisite: [OpenJDK 17](https://adoptium.net/)*
 
 Generate runtime images `build/image/artishock-{linux,mac,win}/`
 ```


### PR DESCRIPTION
Update linked text to 'OpenJDK 17'. Missed this in the previous PR.