### PR TITLE
add a 'uberJar' command to build a jar that is runnable directly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ tasks.register('uberJar', Jar) {
 
   manifest {
     attributes 'Main-Class': 'com.schibsted.security.artishock.ArtishockCli'
+    attributes 'Multi-Release': 'true'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,22 @@ java {
   targetCompatibility = JavaVersion.VERSION_17
 }
 
+tasks.register('uberJar', Jar) {
+  archiveClassifier = 'uber'
+  duplicatesStrategy = 'exclude'
+
+  from sourceSets.main.output
+
+  dependsOn configurations.runtimeClasspath
+  from {
+    configurations.runtimeClasspath.findAll { it.name.endsWith('jar') }.collect { zipTree(it) }
+  }
+
+  manifest {
+    attributes 'Main-Class': 'com.schibsted.security.artishock.ArtishockCli'
+  }
+}
+
 runtime {
   options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
   imageZip = file("$buildDir/artishock.zip")


### PR DESCRIPTION
Creating a jar file with all it's dependencies compiled into the jar and a manifest makes it a lot easier to distribute.

With this patch:

```
capitol@phoenix:~/projects/artishock$ gradle clean

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 421ms
1 actionable task: 1 executed
capitol@phoenix:~/projects/artishock$ gradle uberJar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2s
2 actionable tasks: 2 executed
capitol@phoenix:~/projects/artishock$ /opt/openjdk/jdk-17/bin/java -jar build/libs/artishock-uber.jar 
usage: artishock <command> [<args>]

The most commonly used artishock commands are:
    cached               Local packages that exist upstream and have been cached by Artifactory
    exclude-candidates   Packages that are candidates to be excluded
    help                 Help
    inferred-exclude     Infer excluded packages (best effort)
    not-claimed          Local packages not claimed upstream
    package-stats        Stats for a given package in Artifactory by iterating recursively (can be slow)
    repo-ls              List Artifactory repositories
    repo-stats           Stats for a given Artifactory repository by iterating over all files (slow)
    version              Get version

See 'artishock help <command>' for more information on a specific command.

```