### PR TITLE
fix a build warning about using deprecated functions in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ plugins {
 
 repositories {
   mavenCentral()
-  jcenter()
 }
 
 mainClassName = 'com.schibsted.security.artishock.ArtishockCli'
@@ -26,7 +25,7 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp:4.9.0")
   implementation("io.airlift:airline:0.8")
 
-  implementation("org.jfrog.artifactory.client:artifactory-java-client-services:2.8.6")
+  implementation("org.jfrog.artifactory.client:artifactory-java-client-services:2.13.0")
   implementation("org.codehaus.groovy:groovy:3.0.6") // Force upgrade in artifactory client
 }
 


### PR DESCRIPTION
The warning:

```
$ gradle uberJar --warning-mode all

> Configure project :
The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.6/userguide/upgrading_version_6.html#jcenter_deprecation
        at build_4acdp2dqzaqtmv7xpcwm8kgfj$_run_closure1.doCall(/home/capitol/projects/artishock/build.gradle:13)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

BUILD SUCCESSFUL in 553ms
2 actionable tasks: 2 up-to-date
```

`artifactory-java-client-services` was updated due to older versions wasn't available in maven central