### PR TITLE
Retry on 429

### DIFF
--- a/src/main/java/com/schibsted/security/artishock/shared/HttpClient.java
+++ b/src/main/java/com/schibsted/security/artishock/shared/HttpClient.java
@@ -52,7 +52,7 @@ public class HttpClient {
         if (response.code() == 429) {
           retry++;
           try {
-            Thread.sleep(2000);
+            Thread.sleep(5000);
           } catch (InterruptedException ignore) {
           }
         } else {
@@ -63,9 +63,9 @@ public class HttpClient {
       } catch (IOException e) {
         throw new RuntimeException("Failed to fetch " + request.url(), e);
       }
-    } while (retry < 5);
+    } while (retry < 10);
 
-    throw new RuntimeException("more than 5 retries for " + request.url());
+    throw new RuntimeException("more than 10 retries for " + request.url());
   }
 
   private static void throwIfUnauthorized(Response response) {


### PR DESCRIPTION
When getting a 429 from a service (typically npmjs) pause for 2 seconds and then retry to request, do this up to 5 times before throwing an exception