### PR TITLE
In the text output option, don't print an empty line if there is no output

### DIFF
--- a/src/main/java/com/schibsted/security/artishock/cli/view/Renderer.java
+++ b/src/main/java/com/schibsted/security/artishock/cli/view/Renderer.java
@@ -52,7 +52,14 @@ public class Renderer {
   private <T extends Collection<?>> String arrayOutput(T object) {
     return switch (outputFormat) {
       case JSON -> serializeToJSON(object) + "\n";
-      case TEXT -> Joiner.on("\n").join(object.stream().map(Object::toString).collect(Collectors.toList())) + "\n";
+      case TEXT -> {
+        String joined = Joiner.on("\n").join(object.stream().map(Object::toString).collect(Collectors.toList()));
+        if (joined.isEmpty()) {
+          yield joined;
+        } else {
+          yield joined + "\n";
+        }
+      }
       default -> throw new RuntimeException("Unexpected output format");
     };
   }


### PR DESCRIPTION
Original output:

```
capitol@phoenix:~/projects/artishock$ /opt/adoptium/jdk-17.0.1+12/bin/java -jar build/libs/artishock-uber.jar not-claimed --package-system pypi --local pypi-local --query-upstream --excluded some-excluded
one-package-here
capitol@phoenix:~/projects/artishock$ /opt/adoptium/jdk-17.0.1+12/bin/java -jar build/libs/artishock-uber.jar not-claimed --package-system pypi --local pypi-local --query-upstream --excluded all-excluded

capitol@phoenix:~/projects/artishock$ 
```


Output with patch:

```
capitol@phoenix:~/projects/artishock$ /opt/adoptium/jdk-17.0.1+12/bin/java -jar build/libs/artishock-uber.jar not-claimed --package-system pypi --local pypi-local --query-upstream --excluded some-excluded
one-package-here
capitol@phoenix:~/projects/artishock$ /opt/adoptium/jdk-17.0.1+12/bin/java -jar build/libs/artishock-uber.jar not-claimed --package-system pypi --local pypi-local --query-upstream --excluded all-excluded
capitol@phoenix:~/projects/artishock$ 
```
